### PR TITLE
Fix deployment issues

### DIFF
--- a/friendly/index.yaml
+++ b/friendly/index.yaml
@@ -1,0 +1,13 @@
+indexes:
+
+- kind: Group
+  properties:
+  - name: teamMembers
+  - name: groupName
+    direction: asc
+
+- kind: Recommendations
+  properties:
+  - name: groupName
+  - name: timestamp
+    direction: desc

--- a/friendly/pom.xml
+++ b/friendly/pom.xml
@@ -62,7 +62,7 @@
         <version>2.2.0</version>
         <configuration>
           <!-- TODO: set project ID. -->
-          <deploy.projectId>pchua-sps-summer20</deploy.projectId>
+          <deploy.projectId>idwitami-sps-summer20</deploy.projectId>
           <deploy.version>1</deploy.version>
         </configuration>
       </plugin>

--- a/friendly/src/main/webapp/script.js
+++ b/friendly/src/main/webapp/script.js
@@ -16,7 +16,6 @@
  */
 function getLoginStatus() {
     fetch('/login').then(response => response.json()).then((loginStatus) => {
-        console.log(loginStatus);
         const loginElement = document.getElementById('login');
         const groupElement = document.getElementById('groups');
         


### PR DESCRIPTION
- Add `index.yaml` file to add composite indexes on the deployment (details: [here](https://cloud.google.com/datastore/docs/tools/indexconfig)). 
- Remove logging from `script.js`

The problem that we have previously is that we didn't specify **composite indexes**, which is not generated automatically. This error can be seen from gcp platform.

To deploy, 
1. Change program id in the `pom.xml` file
2. Set your project to `gcloud` by `gcloud config set project <PROJECT_ID>`
3. Run `gcloud datastore indexes create index.yaml` to add your indexes
4. Unset your project by `gcloud config unset project`

You can also see your indexes on the gcp platform.